### PR TITLE
Allow full mocking of all observations

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -116,6 +116,9 @@ interface MetarData {
  * Interface representing query parameters.
  */
 interface QueryParams {
+    __gusts?: string;
+    __speeds?: string;
+    __directions?: string;
     debug?: string;
     mock?: string;
     rc?: string;
@@ -128,8 +131,6 @@ interface QueryParams {
     observation_range?: string;
     forecast_day?: string;
     forecast_range?: string;
-    direction?: string;
-    gust?: string;
     css?: string;
     high_winds_details?: string;
     flyk_metar?: string;


### PR DESCRIPTION
Nyt pystyy mockaamaan localhostissa kaikki havaintoarvot testaamista varten.

urliin lisätään vaan `&__directions=10,90,180,270,260,300,270,270,270,90,90,90,90,90,0&__gusts=1,2,3,4,5,6,7,8,9.4,12.2`

Joissa viimeinen arvo uusin. Eli toi numerojono ylikirjoittaa luettuja havaintoja.

Esim. http://localhost:8000/dz/?fmisid=137208&icaocode=EFJY&__directions=10,90,180,270,260,300,270,270,270,90,90,90,90,90,0&__gusts=1,2,3,4,5,6,7,8,9.4,12.2

<img width="223" alt="image" src="https://github.com/user-attachments/assets/d27e22ce-98e4-473c-9242-a938e3694de1">
